### PR TITLE
Add support for .NET 10

### DIFF
--- a/src/presentation/NuGone.Cli/NuGone.Cli.csproj
+++ b/src/presentation/NuGone.Cli/NuGone.Cli.csproj
@@ -17,6 +17,7 @@
     <PackageTags>nuget;packages;cleanup;dotnet;cli</PackageTags>
     <PackAsTool>true</PackAsTool>
     <RepositoryUrl>https://github.com/ahmet-cetinkaya/nugone</RepositoryUrl>
+    <RollForward>Major</RollForward>
     <TargetFramework>net9.0</TargetFramework>
     <ToolCommandName>nugone</ToolCommandName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
This allows to run the tool with .NET 10 and future versions of .NET.

## Summary by Sourcery

Build:
- Update the NuGone.Cli project configuration to roll forward to newer major .NET runtime versions when available.